### PR TITLE
add w3q chain id to ethereum list

### DIFF
--- a/_data/chains/eip155-333.json
+++ b/_data/chains/eip155-333.json
@@ -11,7 +11,7 @@
     "symbol": "W3Q",
     "decimals": 18
   },
-  "infoURL": "https://web3q.io",
+  "infoURL": "https://web3q.io/home.w3q/",
   "shortName": "w3q",
   "chainId": 333,
   "networkId": 333,

--- a/_data/chains/eip155-333.json
+++ b/_data/chains/eip155-333.json
@@ -1,13 +1,13 @@
 {
-  "name": "W3Q Mainnet",
-  "chain": "W3Q",
+  "name": "Web3Q Mainnet",
+  "chain": "Web3Q",
   "rpc": [
     "https://mainnet.web3q.io:8545"
   ],
   "faucets": [
   ],
   "nativeCurrency": {
-    "name": "W3Q",
+    "name": "Web3Q",
     "symbol": "W3Q",
     "decimals": 18
   },

--- a/_data/chains/eip155-333.json
+++ b/_data/chains/eip155-333.json
@@ -1,0 +1,23 @@
+{
+  "name": "W3Q Mainnet",
+  "chain": "W3Q",
+  "rpc": [
+    "https://mainnet.web3q.io:8545"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "W3Q",
+    "symbol": "W3Q",
+    "decimals": 18
+  },
+  "infoURL": "https://web3q.io",
+  "shortName": "w3q",
+  "chainId": 333,
+  "networkId": 333,
+  "explorers": [{
+    "name": "w3q-mainnet",
+    "url": "http://explorer.mainnet.web3q.io",
+    "standard": "EIP3091"
+  }]
+}

--- a/_data/chains/eip155-3333.json
+++ b/_data/chains/eip155-3333.json
@@ -1,0 +1,23 @@
+{
+  "name": "W3Q Testnet",
+  "chain": "W3Q",
+  "rpc": [
+    "https://testnet.web3q.io:8545"
+  ],
+  "faucets": [
+  ],
+  "nativeCurrency": {
+    "name": "W3Q",
+    "symbol": "W3Q",
+    "decimals": 18
+  },
+  "infoURL": "https://web3q.io",
+  "shortName": "w3q-t",
+  "chainId": 3333,
+  "networkId": 3333,
+  "explorers": [{
+    "name": "w3q-testnet",
+    "url": "http://explorer.testnet.web3q.io",
+    "standard": "EIP3091"
+  }]
+}

--- a/_data/chains/eip155-3333.json
+++ b/_data/chains/eip155-3333.json
@@ -1,13 +1,13 @@
 {
-  "name": "W3Q Testnet",
-  "chain": "W3Q",
+  "name": "Web3Q Testnet",
+  "chain": "Web3Q",
   "rpc": [
     "https://testnet.web3q.io:8545"
   ],
   "faucets": [
   ],
   "nativeCurrency": {
-    "name": "W3Q",
+    "name": "Web3Q",
     "symbol": "W3Q",
     "decimals": 18
   },

--- a/_data/chains/eip155-3333.json
+++ b/_data/chains/eip155-3333.json
@@ -11,7 +11,7 @@
     "symbol": "W3Q",
     "decimals": 18
   },
-  "infoURL": "https://web3q.io",
+  "infoURL": "https://web3q.io/home.w3q/",
   "shortName": "w3q-t",
   "chainId": 3333,
   "networkId": 3333,


### PR DESCRIPTION
add W3Q Testnet (chainid = 3333) and W3Q Mainnet (chainid = 333) to ethereum list.
issue: https://github.com/QuarkChain/web3q-master-task/issues/1 
