### PR TITLE
Add chain id 100011/110011  for quarkchain l2 (mainnet/testnet)

### DIFF
--- a/_data/chains/eip155-100011.json
+++ b/_data/chains/eip155-100011.json
@@ -1,8 +1,8 @@
 {
-  "name": "QuarkChain L2 Testnet",
+  "name": "QuarkChain L2 Mainnet",
   "chain": "QuarkChain",
   "rpc": [
-    "https://testnet-l2-ethapi.quarkchain.io",
+    "https://mainnet-l2-ethapi.quarkchain.io",
   ],
   "faucets": [],
   "nativeCurrency": {
@@ -11,17 +11,17 @@
     "decimals": 18
   },
   "infoURL": "https://www.quarkchain.io",
-  "shortName": "qkc-l2-t",
-  "chainId": 110009,
-  "networkId": 110009,
+  "shortName": "qkc-l2",
+  "chainId": 100011,
+  "networkId": 100011,
   "parent": {
     "type": "L2",
-    "chain": "eip155-110000"
+    "chain": "eip155-100000"
   },
   "explorers": [
     {
-      "name": "quarkchain-l2-testnet",
-      "url": "https://explorer.testnet.l2.quarkchain.io",
+      "name": "quarkchain-l2-mainnet",
+      "url": "https://explorer.mainnet.l2.quarkchain.io",
       "standard": "EIP3091"
     }
   ]

--- a/_data/chains/eip155-110009.json
+++ b/_data/chains/eip155-110009.json
@@ -1,0 +1,28 @@
+{
+  "name": "QuarkChain L2 Testnet",
+  "chain": "QuarkChain",
+  "rpc": [
+    "https://testnet-l2-ethapi.quarkchain.io",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "QKC",
+    "symbol": "QKC",
+    "decimals": 18
+  },
+  "infoURL": "https://www.quarkchain.io",
+  "shortName": "qkc-l2-t",
+  "chainId": 110009,
+  "networkId": 110009,
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-110000"
+  },
+  "explorers": [
+    {
+      "name": "quarkchain-l2-testnet",
+      "url": "https://explorer.testnet.l2.quarkchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}

--- a/_data/chains/eip155-110011.json
+++ b/_data/chains/eip155-110011.json
@@ -1,0 +1,28 @@
+{
+  "name": "QuarkChain L2 Testnet",
+  "chain": "QuarkChain",
+  "rpc": [
+    "https://testnet-l2-ethapi.quarkchain.io",
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "QKC",
+    "symbol": "QKC",
+    "decimals": 18
+  },
+  "infoURL": "https://www.quarkchain.io",
+  "shortName": "qkc-l2-t",
+  "chainId": 110011,
+  "networkId": 110011,
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-110000"
+  },
+  "explorers": [
+    {
+      "name": "quarkchain-l2-testnet",
+      "url": "https://explorer.testnet.l2.quarkchain.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Just reserve chain id 100011/110011 for quarkchain l2 mainnet/testnet. We are still working on rpc (https://mainnet-l2-ethapi.quarkchain.io, https://testnet-l2-ethapi.quarkchain.io) and explorer (https://explorer.mainnet.l2.quarkchain.io, https://explorer.testnet.l2.quarkchain.io), and we will update these values ​​later.